### PR TITLE
fix: add .js extension to internal export so strict Node ESM resolves

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 // Reexport your entry components here
 
-export * from './utils/main'
+export * from './utils/main.js'


### PR DESCRIPTION
## Summary

One-line fix: add the explicit `.js` extension to the internal re-export in `src/lib/index.ts` so strict Node ESM consumers can resolve it.

## Why this matters

The published `dist/index.js` mirrors the source verbatim:

```js
// dist/index.js (current)
export * from './utils/main'
```

When the package is consumed from an environment that uses strict Node ESM resolution — for example, a Vite plugin imported from `vite.config.ts`, where Vite externalizes `node_modules` rather than bundling them — Node throws:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../svelte-satori-fix/dist/utils/main'
imported from .../svelte-satori-fix/dist/index.js
```

Strict ESM requires the explicit extension. `tsx`/`ts-node` and Vite's transform pipeline tolerate the missing extension, which is why this only surfaces when a consumer reaches `svelte-satori-fix` through pure Node ESM resolution.

After this change the dist becomes:

```js
export * from './utils/main.js'
```

…which resolves correctly under every loader.

## Verification

```bash
pnpm test
# 8 passed (2 files)
```

No behavior change — just unbreaks the strict-ESM consumption path.

## Commits

- [`3239af0`](https://github.com/humanspeak/svelte-satori-fix/commit/3239af0) fix: add .js extension to internal export so strict Node ESM resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
