### PR TITLE
ci: standardize workflow validation

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,8 +1,8 @@
 name: Validate Workflows
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read # required for actions/checkout
+    pull-requests: read # only needed for fork PRs
 
 on:
     pull_request:
@@ -21,7 +21,7 @@ jobs:
                   fetch-depth: 0 # Fetch full history for git comparisons
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6 # zizmor: ignore[unpinned-uses]
               with:
                   python-version: '3.12'
 
@@ -100,7 +100,6 @@ jobs:
                   echo "$HOME/.local/bin" >> $GITHUB_PATH
 
             - name: Validate all workflows
-              working-directory: .github/workflows
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   BASE_REF: ${{ github.base_ref }}
@@ -110,12 +109,15 @@ jobs:
 
                   # Initialize error flag
                   has_errors=0
+                  # Prepare logs directory at repository root
+                  LOG_DIR="${GITHUB_WORKSPACE}/zizmor-logs"
+                  mkdir -p "${LOG_DIR}"
 
                   # Validate inputs
                   if [ -z "${BASE_REF:-}" ]; then
                       echo "::warning::BASE_REF is not set, validating all workflow files"
-                      # If no base ref (manual trigger), validate all workflows
-                      changed_files=$(find . -name "*.yml" -o -name "*.yaml" | sed 's|^\./||' || true)
+                      # If no base ref (manual trigger), validate all workflows under .github/workflows
+                      changed_files=$(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) || true)
                   else
                       echo "Comparing against base ref: $BASE_REF"
 
@@ -136,7 +138,7 @@ jobs:
                       else
                           echo "::warning::Cannot find base ref ${BASE_REF} in any form"
                           echo "Falling back to validating all workflow files"
-                          changed_files=$(find . -name "*.yml" -o -name "*.yaml" | sed 's|^\./||' || true)
+                          changed_files=$(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) || true)
                       fi
                   fi
 
@@ -144,6 +146,8 @@ jobs:
 
                   if [ -z "$changed_files" ]; then
                       echo "No workflow files changed"
+                      # Still write an empty marker so downstream steps succeed
+                      echo 0 > "${LOG_DIR}/has_errors.txt"
                       exit 0
                   fi
 
@@ -151,32 +155,50 @@ jobs:
                   while IFS= read -r file; do
                       [ -z "$file" ] && continue
 
-                      # Safely handle filenames
-                      filename=$(basename -- "$file")
-
                       # Skip files that were deleted or do not exist in the checkout
-                      if [ ! -f "$filename" ]; then
-                          echo "Skipping $filename (not present in current checkout — likely deleted or renamed)"
+                      if [ ! -f "$file" ]; then
+                          echo "Skipping $file (not present in current checkout — likely deleted or renamed)"
                           continue
                       fi
 
-                      # Skip non-yaml files
-                      if [[ ! "$filename" =~ \.(ya?ml)$ ]]; then
+                      # Skip non-yaml files (defensive)
+                      if [[ ! "$file" =~ \.(ya?ml)$ ]]; then
                           continue
                       fi
 
-                      echo "Validating $filename..."
-
-                      if ! zizmor "$filename" 2>/dev/null; then
-                          echo "::error::Validation failed for $filename"
+                      echo "Validating $file..."
+                      safe_name=$(basename -- "$file")
+                      # Capture zizmor output per-file to logs for troubleshooting
+                      if ! zizmor "$file" > "${LOG_DIR}/${safe_name}.log" 2>&1; then
+                          echo "::error::Validation failed for $file (see artifact zizmor-logs/${safe_name}.log)"
                           has_errors=1
+                      else
+                          echo "Validation passed for $file" | tee -a "${LOG_DIR}/${safe_name}.log" >/dev/null
                       fi
                   done <<< "$changed_files"
 
-                  # Exit with error if any validation failed
-                  if [ "$has_errors" -eq 1 ]; then
-                      echo "::error::One or more workflow validations failed"
-                      exit 1
+                  # Persist error marker for later steps
+                  echo $has_errors > "${LOG_DIR}/has_errors.txt"
+
+                  if [ "$has_errors" -eq 0 ]; then
+                      echo "All workflows validated successfully"
+                  else
+                      echo "One or more workflow validations failed (logs uploaded)"
                   fi
 
-                  echo "All workflows validated successfully"
+            - name: Upload zizmor logs
+              if: always()
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
+              with:
+                  name: zizmor-logs
+                  path: ${{ github.workspace }}/zizmor-logs
+
+            - name: Fail if validation errors
+              if: always()
+              run: |
+                  set -euo pipefail
+                  LOG_DIR="${GITHUB_WORKSPACE}/zizmor-logs"
+                  if [ -f "${LOG_DIR}/has_errors.txt" ] && [ "$(cat "${LOG_DIR}/has_errors.txt")" -eq 1 ]; then
+                      echo "One or more workflow validations failed (see artifact zizmor-logs)"
+                      exit 1
+                  fi


### PR DESCRIPTION
## Summary

Standardizes `.github/workflows/validate-workflows.yml` on the validated workflow version used across the repo set.

## Changes

- 🔄 CI/CD
  - Replace the existing workflow validation file with the approved standard version.
  - Use `actions/setup-python@v6` and `actions/upload-artifact@v7` in validation.

## Commits

- [`6f272bb`](https://github.com/humanspeak/svelte-satori-fix/commit/6f272bb5b5156051055173cbc379de84719076ec) ci: standardize workflow validation
