### PR TITLE
chore(ci): update Trunk setup action refs

### DIFF
--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -4,10 +4,10 @@ runs:
     using: composite
     steps:
         - name: Setup Node.js
-          uses: actions/setup-node@v4 # zizmor: ignore[unpinned-uses]
+          uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
           with:
               node-version: 24
-        - uses: pnpm/action-setup@v4 # zizmor: ignore[unpinned-uses]
+        - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
           with:
               version: 10
 


### PR DESCRIPTION
## Summary

Updates the Trunk setup composite action refs used by CI while preserving the existing Node 24 runtime and package-manager versions.

## Changes

🔄 CI/CD
- actions/setup-node v4 -> v6
- pnpm/action-setup v4 -> v6
- Leaves `node-version: 24` unchanged
- Leaves existing PNPM version values unchanged

## Testing

- Verified the diff is limited to `.trunk/setup-ci/action.yaml`

## Commits

- [`be37794`](https://github.com/humanspeak/svelte-satori-fix/commit/be37794a6ecd534f9b5c5f9ad25d09946900382a) chore(ci): update Trunk setup action refs
