### PR TITLE
chore: gate CodeRabbit reviews behind the coderabbit label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,170 @@
+language: en-US
+tone_instructions: Be concise and technical. Focus on critical issues first (bugs, security, accessibility), then suggestions. Prioritize actionable feedback over observations.
+early_access: false
+enable_free_tier: true
+reviews:
+    profile: assertive
+    request_changes_workflow: false
+    # Disable GitHub PR comments - we use Claude Code locally for reviews
+    high_level_summary: false
+    high_level_summary_placeholder: '@coderabbitai summary'
+    high_level_summary_in_walkthrough: false
+    # Disable auto-title - we craft conventional commits manually
+    auto_title_placeholder: '@coderabbitai'
+    auto_title_instructions: ''
+    # Disable status checks - we use trunk locally
+    review_status: false
+    commit_status: false
+    fail_commit_status: false
+    collapse_walkthrough: true
+    changed_files_summary: false
+    sequence_diagrams: false
+    assess_linked_issues: false
+    related_issues: false
+    related_prs: false
+    suggested_labels: false
+    auto_apply_labels: false
+    suggested_reviewers: false
+    auto_assign_reviewers: false
+    poem: false
+    labeling_instructions:
+        - label: bug
+          instructions: Apply to any code that fixes incorrect behavior or errors
+        - label: enhancement
+          instructions: Apply to new features or improvements to existing features
+        - label: docs
+          instructions: Apply to documentation updates or improvements
+        - label: test
+          instructions: Apply to test additions or improvements
+        - label: refactor
+          instructions: Apply to code restructuring without behavior changes
+        - label: performance
+          instructions: Apply to performance improvements or optimizations
+        - label: security
+          instructions: Apply to security fixes or improvements
+        - label: animation
+          instructions: Apply to changes to animation logic or Motion integration
+        - label: accessibility
+          instructions: Apply to accessibility improvements (a11y, keyboard, screen readers)
+        - label: breaking-change
+          instructions: Apply to changes that break backward compatibility
+    path_filters: []
+    path_instructions:
+        - path: src/lib/utils/**/*.ts
+          instructions: Ensure all exported functions use arrow function syntax (const fn = () => {}). All functions must have comprehensive JSDoc comments with @param, @returns, and @example tags. Verify type safety and check for potential ReDoS vulnerabilities in regex patterns.
+        - path: src/lib/**/*.svelte
+          instructions: Review Svelte 5 runes usage ($state, $derived, $effect). Ensure proper cleanup in $effect blocks. Check for memory leaks and performance issues. Verify SSR compatibility.
+        - path: '**/*.spec.ts'
+          instructions: Ensure tests are comprehensive with good coverage of edge cases, error paths, and accessibility. Tests should be well-named and describe the expected behavior clearly.
+        - path: docs/**/*
+          instructions: Verify examples are correct, runnable, and match current API. Check for broken links and ensure code examples follow project conventions.
+        - path: tests/**/*.ts
+          instructions: Ensure e2e tests are reliable, avoid flakiness, and test real user scenarios. Verify proper waits and assertions.
+        - path: docs/e2e/**/*.ts
+          instructions: Ensure e2e tests are reliable, avoid flakiness, and test real user scenarios. Verify proper waits and assertions.
+    abort_on_close: true
+    disable_cache: false
+    auto_review:
+        enabled: false
+        auto_incremental_review: false
+        ignore_title_keywords: []
+        labels: ['coderabbit']
+        drafts: false
+        base_branches: []
+    finishing_touches:
+        docstrings:
+            enabled: false
+        unit_tests:
+            enabled: false
+    tools:
+        ast-grep:
+            rule_dirs: []
+            util_dirs: []
+            essential_rules: true
+            packages: []
+        shellcheck:
+            enabled: false # Not needed for TS/Svelte project
+        ruff:
+            enabled: false # Python linter - not needed
+        markdownlint:
+            enabled: true
+        github-checks:
+            enabled: true
+            timeout_ms: 90000
+        languagetool:
+            enabled: false
+        biome:
+            enabled: true # Good for TypeScript/JavaScript
+        hadolint:
+            enabled: false # Docker linter - not needed
+        swiftlint:
+            enabled: false # Swift linter - not needed
+        phpstan:
+            enabled: false # PHP linter - not needed
+            level: default
+        golangci-lint:
+            enabled: false # Go linter - not needed
+        yamllint:
+            enabled: true
+        gitleaks:
+            enabled: true # Security - keep enabled
+        checkov:
+            enabled: false # Infrastructure security - not needed
+        detekt:
+            enabled: false # Kotlin linter - not needed
+        eslint:
+            enabled: true # Essential for TypeScript/JavaScript
+        rubocop:
+            enabled: false # Ruby linter - not needed
+        buf:
+            enabled: false # Protobuf linter - not needed
+        regal:
+            enabled: false # Rego linter - not needed
+        actionlint:
+            enabled: true # Useful for GitHub Actions
+        pmd:
+            enabled: false # Java linter - not needed
+        cppcheck:
+            enabled: false # C/C++ linter - not needed
+        semgrep:
+            enabled: true # Security patterns - useful
+        circleci:
+            enabled: false # Not using CircleCI
+        sqlfluff:
+            enabled: false # SQL linter - not needed
+        prismaLint:
+            enabled: false # Prisma ORM - not needed
+        oxc:
+            enabled: true # Fast JavaScript/TypeScript linter
+        shopifyThemeCheck:
+            enabled: false # Shopify themes - not needed
+chat:
+    # Disable auto-reply - we interact via Claude Code, not GitHub comments
+    auto_reply: false
+    integrations:
+        jira:
+            usage: disabled
+        linear:
+            usage: disabled
+knowledge_base:
+    opt_out: false
+    web_search:
+        enabled: false
+    learnings:
+        scope: local
+    issues:
+        scope: local
+    jira:
+        usage: disabled
+        project_keys: []
+    linear:
+        usage: disabled
+        team_keys: []
+    pull_requests:
+        scope: local
+# Code generation disabled - we write docs and tests via Claude Code
+code_generation:
+    docstrings:
+        enabled: false
+    unit_tests:
+        enabled: false


### PR DESCRIPTION
## What

Gates CodeRabbit auto-reviews behind the `coderabbit` label and stops per-push re-reviews, so simple fast-moving PRs no longer burn the hourly rate limit.

- `reviews.auto_review.enabled: false` — no automatic review on every PR
- `reviews.auto_review.labels: ['coderabbit']` — adding the `coderabbit` label triggers a review (per CodeRabbit docs, the labels trigger works even when `enabled` is false)
- `reviews.auto_review.auto_incremental_review: false` — pushes no longer re-trigger reviews

## How to invoke a review now

- Add the `coderabbit` label to the PR (created in this repo alongside this PR), or
- Comment `@coderabbitai review` (incremental) / `@coderabbitai full review` on any PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Note: this repo had no `.coderabbit.yaml`, so the file is seeded from the org baseline (`svelte-markdown`) with the label gating applied. The `path_instructions` / `labeling_instructions` in the baseline are Svelte-package-oriented — trim if irrelevant here.

@coderabbitai ignore
