### PR TITLE
chore: add t3.json project icon

### DIFF
--- a/t3.json
+++ b/t3.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://t3.codes/schema/t3.json",
+    "iconPath": "static/favicon.svg"
+}


### PR DESCRIPTION
Adds a checked-in `t3.json` pointing T3 Code's project-icon discovery at `static/favicon.svg`. T3 Code's built-in favicon candidates don't cover SvelteKit's `static/` (or nested app) layouts, so these repos currently render the generic folder icon in the sidebar. `iconPath` is checked before the built-in locations, fixing it for everyone who opens the repo.

No runtime, build, or package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)