### PR TITLE
ci: trigger post-merge publish and deploy on push to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,15 +20,15 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
               with:
                   persist-credentials: false
                   fetch-depth: 0
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v3
+              uses: github/codeql-action/init@v4
               with:
                   languages: javascript
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3
+              uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -19,7 +19,7 @@ jobs:
                 node-version: [20, 22, 24]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -29,7 +29,7 @@ jobs:
                   version: 10
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -49,7 +49,7 @@ jobs:
               if: matrix.node-version == '22'
 
             - name: Cache dependencies
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/npm-prerelease.yml
+++ b/.github/workflows/npm-prerelease.yml
@@ -50,7 +50,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
                   version: 10
 
             - name: Use Node.js 22
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
@@ -81,7 +81,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -92,7 +92,7 @@ jobs:
                   version: 10
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
                   registry-url: https://registry.npmjs.org
@@ -103,7 +103,7 @@ jobs:
 
             - name: Import GPG key
               id: import_gpg
-              uses: crazy-max/ghaction-import-gpg@v6 # zizmor: ignore[unpinned-uses]
+              uses: crazy-max/ghaction-import-gpg@v7 # zizmor: ignore[unpinned-uses]
               with:
                   gpg_private_key: ${{ secrets.ACTIONS_GPG_PRIVATE_KEY }}
                   passphrase: ${{ secrets.ACTIONS_GPG_PASSPHRASE }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,12 +7,18 @@ permissions:
     pull-requests: read
 
 # 2. Trigger conditions
+#
+# Runs on push to main rather than pull_request[closed]: GitHub withholds
+# secrets from pull_request events triggered by fork PRs — even the merged
+# close event — so publishes silently failed for external contributions
+# (first hit: PR #466). Push events always run in the base repo with
+# secrets. PR context (labels, title, URL) is recovered by API lookup in
+# check-if-merged. The version-bump commit is "[skip ci]" so it can't
+# retrigger this workflow.
 on:
-    pull_request:
-        types: [closed]
+    push:
         branches:
             - main
-            - '!dependabot/**'
         paths:
             - src/**
             - '!docs/**'
@@ -45,20 +51,70 @@ jobs:
         outputs:
             should_run: ${{ steps.check.outputs.should_run }}
             has_skip_label: ${{ steps.check.outputs.has_skip_label }}
+            has_major: ${{ steps.check.outputs.has_major }}
+            has_minor: ${{ steps.check.outputs.has_minor }}
+            pr_number: ${{ steps.check.outputs.pr_number }}
+            pr_title: ${{ steps.check.outputs.pr_title }}
+            pr_url: ${{ steps.check.outputs.pr_url }}
         steps:
+            # Push payloads carry no PR context, so recover the merged PR (for
+            # skip-publish/major/minor labels and release notes) from the commit.
+            - id: pr
+              if: github.event_name == 'push'
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
+              with:
+                  script: |
+                      const { owner, repo } = context.repo
+                      const { data: prs } =
+                          await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                              owner,
+                              repo,
+                              commit_sha: context.sha
+                          })
+                      const pr = prs.find((candidate) => candidate.merged_at)
+                      if (!pr) {
+                          core.info(`No merged PR associated with ${context.sha}`)
+                          return
+                      }
+                      const labels = pr.labels.map((label) => label.name)
+                      core.setOutput('found', 'true')
+                      core.setOutput('number', String(pr.number))
+                      core.setOutput('title', pr.title)
+                      core.setOutput('url', pr.html_url)
+                      core.setOutput('has_skip_label', String(labels.includes('skip-publish')))
+                      core.setOutput('has_major', String(labels.includes('major')))
+                      core.setOutput('has_minor', String(labels.includes('minor')))
+
             - id: check
               env:
                   EVENT_NAME: ${{ github.event_name }}
-                  PR_MERGED: ${{ github.event.pull_request.merged }}
-                  HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-publish') }}
+                  PR_FOUND: ${{ steps.pr.outputs.found }}
+                  PR_NUMBER: ${{ steps.pr.outputs.number }}
+                  PR_TITLE: ${{ steps.pr.outputs.title }}
+                  PR_URL: ${{ steps.pr.outputs.url }}
+                  HAS_SKIP_LABEL: ${{ steps.pr.outputs.has_skip_label }}
+                  HAS_MAJOR: ${{ steps.pr.outputs.has_major }}
+                  HAS_MINOR: ${{ steps.pr.outputs.has_minor }}
               run: |
-                  if [[ "$EVENT_NAME" == "pull_request" && "$PR_MERGED" != "true" ]]; then
+                  # Pushes publish only when the commit landed via a merged PR;
+                  # direct pushes to main stay unpublished (same behavior as the
+                  # old pull_request[closed] trigger). Dispatch always runs.
+                  if [[ "$EVENT_NAME" == "push" && "$PR_FOUND" != "true" ]]; then
                       echo "should_run=false" >> $GITHUB_OUTPUT
                   else
                       echo "should_run=true" >> $GITHUB_OUTPUT
                   fi
 
-                  echo "has_skip_label=$HAS_SKIP_LABEL" >> $GITHUB_OUTPUT
+                  echo "has_skip_label=${HAS_SKIP_LABEL:-false}" >> $GITHUB_OUTPUT
+                  echo "has_major=${HAS_MAJOR:-false}" >> $GITHUB_OUTPUT
+                  echo "has_minor=${HAS_MINOR:-false}" >> $GITHUB_OUTPUT
+                  echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+                  {
+                      echo "pr_title<<PR_TITLE_EOF"
+                      echo "$PR_TITLE"
+                      echo "PR_TITLE_EOF"
+                  } >> $GITHUB_OUTPUT
+                  echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
     debug-check:
         needs: check-if-merged
@@ -67,7 +123,7 @@ jobs:
         environment: ci
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -156,8 +212,10 @@ jobs:
                   [[ $OUTPUT == *"::error"* ]] && exit 1 || exit 0
 
             - name: Upload Results
-              if: failure() && github.event_name == 'pull_request'
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              if: failure() && github.event_name == 'push' && needs.check-if-merged.outputs.pr_number != ''
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
+              env:
+                  PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
@@ -183,7 +241,7 @@ jobs:
                       commentBody += '\nPlease remove these debugging statements before merging.';
 
                       github.rest.issues.createComment({
-                          issue_number: context.issue.number,
+                          issue_number: Number(process.env.PR_NUMBER),
                           owner: owner,
                           repo: repo,
                           body: commentBody
@@ -212,7 +270,7 @@ jobs:
             packages: write
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -222,7 +280,7 @@ jobs:
                   version: 10
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -237,6 +295,9 @@ jobs:
 
             - name: Upload Vitest Results
               if: always()
+              # Telemetry only — a flaky upload must never block the release
+              # (a "fetch failed" here blocked the v0.9.0 publish on 2026-08-12).
+              continue-on-error: true
               uses: trunk-io/analytics-uploader@main # zizmor: ignore[unpinned-uses]
               with:
                   junit-paths: junit-vitest.xml
@@ -289,7 +350,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.GITHUB_TOKEN }}
@@ -300,7 +361,7 @@ jobs:
                   version: 10
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses,cache-poisoning]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses,cache-poisoning]
               with:
                   node-version: 24
 
@@ -311,22 +372,19 @@ jobs:
               id: publish-check
               env:
                   EVENT_NAME: ${{ github.event_name }}
-                  IS_MERGED: ${{ github.event.pull_request.merged }}
-                  HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-publish') }}
+                  HAS_SKIP_LABEL: ${{ needs.check-if-merged.outputs.has_skip_label }}
                   INPUT_VERSION: ${{ github.event.inputs.version_bump }}
               run: |
                   # Validate event name first
-                  if [[ "$EVENT_NAME" != "pull_request" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
+                  if [[ "$EVENT_NAME" != "push" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
                     echo "Invalid event type"
                     exit 1
                   fi
 
-                  # Check publishing conditions
-                  if [[ "$EVENT_NAME" == "pull_request" ]]; then
-                    if [[ "$IS_MERGED" != "true" ]]; then
-                      echo "PR not merged, skipping publish"
-                      echo "should_publish=false" >> $GITHUB_OUTPUT
-                    elif [[ "$HAS_SKIP_LABEL" == "true" ]]; then
+                  # Check publishing conditions (check-if-merged already gated
+                  # push events on an associated merged PR)
+                  if [[ "$EVENT_NAME" == "push" ]]; then
+                    if [[ "$HAS_SKIP_LABEL" == "true" ]]; then
                       echo "Publishing skipped due to skip-publish label"
                       echo "should_publish=false" >> $GITHUB_OUTPUT
                     else
@@ -340,13 +398,15 @@ jobs:
                   fi
 
             - name: Create Comment on Skip
-              if: github.event_name == 'pull_request' && steps.publish-check.outputs.should_publish == 'false'
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              if: github.event_name == 'push' && steps.publish-check.outputs.should_publish == 'false' && needs.check-if-merged.outputs.pr_number != ''
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
+              env:
+                  PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
                       github.rest.issues.createComment({
-                          issue_number: context.issue.number,
+                          issue_number: Number(process.env.PR_NUMBER),
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           body: '⏭️ NPM publishing was skipped due to the `skip-publish` label.'
@@ -355,7 +415,7 @@ jobs:
             - name: Import GPG key
               if: steps.publish-check.outputs.should_publish == 'true'
               id: import_gpg
-              uses: crazy-max/ghaction-import-gpg@v6 # zizmor: ignore[unpinned-uses]
+              uses: crazy-max/ghaction-import-gpg@v7 # zizmor: ignore[unpinned-uses]
               with:
                   gpg_private_key: ${{ secrets.ACTIONS_GPG_PRIVATE_KEY }}
                   passphrase: ${{ secrets.ACTIONS_GPG_PASSPHRASE }}
@@ -368,8 +428,8 @@ jobs:
               if: steps.publish-check.outputs.should_publish == 'true'
               id: version-type
               env:
-                  HAS_MAJOR: ${{ contains(github.event.pull_request.labels.*.name, 'major') }}
-                  HAS_MINOR: ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
+                  HAS_MAJOR: ${{ needs.check-if-merged.outputs.has_major }}
+                  HAS_MINOR: ${{ needs.check-if-merged.outputs.has_minor }}
                   INPUT_VERSION: ${{ github.event.inputs.version_bump }}
               run: |
                   # Function to validate version bump type
@@ -403,8 +463,8 @@ jobs:
               if: steps.publish-check.outputs.should_publish == 'true'
               id: version
               env:
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  PR_TITLE: ${{ needs.check-if-merged.outputs.pr_title }}
+                  PR_URL: ${{ needs.check-if-merged.outputs.pr_url }}
                   BUMP_TYPE: ${{ steps.version-type.outputs.bump }}
                   GITHUB_TOKEN: ${{ secrets.ACTIONS_KEY }}
                   GPG_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
@@ -465,12 +525,12 @@ jobs:
                   NEW_VERSION: ${{ steps.version.outputs.new_version }}
                   EVENT_NAME: ${{ github.event_name }}
                   CUSTOM_MESSAGE: ${{ github.event.inputs.custom_message }}
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  PR_TITLE: ${{ needs.check-if-merged.outputs.pr_title }}
+                  PR_URL: ${{ needs.check-if-merged.outputs.pr_url }}
               run: |
                   BODY="Changes in this Release
                   ${CUSTOM_MESSAGE:-$PR_TITLE}"
-                  if [[ "$EVENT_NAME" == "pull_request" ]]; then
+                  if [[ "$EVENT_NAME" == "push" && -n "$PR_URL" ]]; then
                       BODY="$BODY
 
                   For more details, see the [Pull Request]($PR_URL)"
@@ -508,13 +568,15 @@ jobs:
                   git push --delete origin "$RELEASE_VERSION" || true
 
             - name: Notify on failure
-              if: failure()
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              if: failure() && needs.check-if-merged.outputs.pr_number != ''
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
+              env:
+                  PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
                       github.rest.issues.createComment({
-                          issue_number: context.issue.number,
+                          issue_number: Number(process.env.PR_NUMBER),
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           body: '❌ Release workflow failed. Please check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -41,12 +41,12 @@ jobs:
                   version: 10
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
             - name: Cache build artifacts
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       .svelte-kit
@@ -56,7 +56,7 @@ jobs:
                       ${{ runner.os }}-build-
 
             - name: Cache vitest artifacts
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       node_modules/.vitest
@@ -73,7 +73,7 @@ jobs:
 
             - name: Upload unit test results
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: unit-test-results
                   path: |

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
 
         steps:
-            - uses: actions/stale@v10 # zizmor: ignore[unpinned-uses]
+            - uses: actions/stale@v11 # zizmor: ignore[unpinned-uses]
               with:
                   # PR specific settings
                   stale-pr-message: This PR is being marked as stale due to 30 days of inactivity. It will be closed in 5 days if no further activity occurs.

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
 

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -15,13 +15,13 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 0 # Fetch full history for git comparisons
 
             - name: Set up Python
-              uses: actions/setup-python@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-python@v7 # zizmor: ignore[unpinned-uses]
               with:
                   python-version: '3.12'
 
@@ -40,7 +40,7 @@ jobs:
                   fi
 
             - name: Cache uv installation
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.local/bin/uv
                   key: ${{ runner.os }}-uv-${{ steps.uv-version.outputs.version }}
@@ -64,7 +64,7 @@ jobs:
                   # echo "version=test-version-$(date +%s)" >> $GITHUB_OUTPUT
 
             - name: Cache zizmor tool
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       ~/.local/bin/zizmor

--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -4,7 +4,7 @@ runs:
     using: composite
     steps:
         - name: Setup Node.js
-          uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+          uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
           with:
               node-version: 24
         - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Mirror of humanspeak/svelte-motion#468 for this repo.

## Why

GitHub withholds repository secrets from `pull_request` events triggered by fork PRs — including the merged `closed` event. Our post-merge npm publish ran on `pull_request[closed]`, so publishes silently failed whenever an external contribution merged (first hit: svelte-motion PR #466).

## What changed

### Push-trigger migration (`npm-publish.yml`)
- Trigger is now `push` to `main` (same `paths:` filter, `workflow_dispatch` kept). Push events always run in the base repo with secrets.
- Push payloads carry no PR context, so `check-if-merged` recovers the merged PR from the commit via `listPullRequestsAssociatedWithCommit` (github-script@v9) and exposes `has_skip_label`, `has_major`, `has_minor`, `pr_number`, `pr_title`, `pr_url` as job outputs.
- All downstream `github.event.pull_request.*` references (labels, title, URL, comment targets) now read from those outputs; PR-comment steps are guarded with `pr_number != ''`.
- Direct pushes to main with no associated merged PR still skip publishing — same behavior as the old trigger.

### Action version bumps (all workflows + `.trunk/setup-ci/action.yaml`)
`checkout` v7, `setup-node` v7, `cache` v6, `upload-artifact` v7, `github-script` v9, `setup-python` v7, `codeql-action` v4, `stale` v11, `crazy-max/ghaction-import-gpg` v7.

### Trunk unit-test upload hardening
The "Upload Vitest Results" trunk analytics step in the publish pipeline is now `continue-on-error: true` — telemetry only, so a flaky upload can never block a release (a "fetch failed" there blocked svelte-motion's v0.9.0 publish on 2026-08-12). The vitest junit reporter already writes `junit-vitest.xml`, matching the uploader's `junit-paths`.

Notes for this repo: there is no cloudflare deploy workflow and no playwright config here, so those parts of the svelte-motion change don't apply. `npm-prerelease.yml` only needed the action bumps (its push trigger targets feature/prerelease branches, not main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)